### PR TITLE
AmazonSQS.Receive - Implemented internal Result classes

### DIFF
--- a/Frends.AmazonSQS.Receive/CHANGELOG.md
+++ b/Frends.AmazonSQS.Receive/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.1.0] - 2024-11-08
+### Fixed
+- Fixed dotnotation with Result properties by implementing internal classes for the properties.
+
 ## [1.0.0] - 2023-08-11
 ### Added
 - Initial implementation 

--- a/Frends.AmazonSQS.Receive/Frends.AmazonSQS.Receive.Tests/UnitTests.cs
+++ b/Frends.AmazonSQS.Receive/Frends.AmazonSQS.Receive.Tests/UnitTests.cs
@@ -47,7 +47,7 @@ public class UnitTests
             SessionToken = string.Empty,
         };
 
-        _msg = $"Frends.AmazonSQS.Receive.Tests.SendMessage() test.\nDatetime: {DateTime.Now.ToString("o")}";
+        _msg = $"Frends.AmazonSQS.Receive.Tests.SendMessage() test.\nDatetime: {DateTime.Now:o}";
         await SendTestMessage(_msg);
     }
 

--- a/Frends.AmazonSQS.Receive/Frends.AmazonSQS.Receive/Definitions/Message.cs
+++ b/Frends.AmazonSQS.Receive/Frends.AmazonSQS.Receive/Definitions/Message.cs
@@ -1,0 +1,54 @@
+﻿using System.Collections.Generic;
+
+namespace Frends.AmazonSQS.Receive.Definitions;
+
+/// <summary>
+/// AmazonSQS message class.
+/// </summary>
+public class Message
+{
+    /// <summary>
+    ///  A map of the attributes requested in ReceiveMessage to their respective values. Supported attributes:
+    ///  ApproximateReceiveCount, ApproximateFirstReceiveTimestamp, MessageDeduplicationId, MessageGroupId, SenderId, SentTimestamp, SequenceNumber.
+    ///  ApproximateFirstReceiveTimestamp and SentTimestamp are each returned as an integer representing the epoch time in milliseconds.
+    /// </summary>
+    public Dictionary<string, string> Attributes { get; set; }
+
+    /// <summary>
+    ///  The message's contents (not URL-encoded).
+    /// </summary>
+    public string Body { get; set; }
+
+    /// <summary>
+    /// An MD5 digest of the non-URL-encoded message body string.
+    /// </summary>
+    public string MD5OfBody { get; set; }
+
+    /// <summary>
+    /// An MD5 digest of the non-URL-encoded message attribute string.
+    /// You can use this attribute to verify that Amazon SQS received the message correctly.
+    /// Amazon SQS URL-decodes the message before creating the MD5 digest. For information about MD5, see RFC1321. 
+    /// </summary>
+    public string MD5OfMessageAttributes { get; set; }
+
+    /// <summary>
+    /// A unique identifier for the message. A MessageIdis considered unique across all Amazon Web Services accounts for an extended period of time.
+    /// </summary>
+    public string MessageId { get; set; }
+
+    /// <summary>
+    /// An identifier associated with the act of receiving the message. A new receipt handle is returned every time you receive a message.
+    /// When deleting a message, you provide the last received receipt handle to delete the message. 
+    /// </summary>
+    public string ReceiptHandle { get; set; }
+
+    internal Message(Amazon.SQS.Model.Message message)
+    {
+        Attributes = message.Attributes;
+        Body = message.Body;
+        MD5OfBody = message.MD5OfBody;
+        MD5OfMessageAttributes = message.MD5OfMessageAttributes;
+        MessageId = message.MessageId;
+        ReceiptHandle = message.ReceiptHandle;
+    }
+}

--- a/Frends.AmazonSQS.Receive/Frends.AmazonSQS.Receive/Definitions/ResponseMetadata.cs
+++ b/Frends.AmazonSQS.Receive/Frends.AmazonSQS.Receive/Definitions/ResponseMetadata.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+
+namespace Frends.AmazonSQS.Receive.Definitions;
+
+/// <summary>
+/// Response metadata class.
+/// </summary>
+public class ResponseMetadata
+{
+    /// <summary>
+    /// Map of response metadata.
+    /// </summary>
+    public IDictionary<string, string> Metadata { get; set; }
+
+    /// <summary>
+    ///  ID that uniquely identifies a request. Amazon keeps track of request IDs. If you have a question about a request, include the request ID in your correspondence.
+    /// </summary>
+    public string RequestId { get; set; }
+
+    internal ResponseMetadata(Amazon.Runtime.ResponseMetadata metadata)
+    {
+        Metadata = metadata.Metadata;
+        RequestId = metadata.RequestId;
+    }
+}

--- a/Frends.AmazonSQS.Receive/Frends.AmazonSQS.Receive/Definitions/Result.cs
+++ b/Frends.AmazonSQS.Receive/Frends.AmazonSQS.Receive/Definitions/Result.cs
@@ -1,6 +1,6 @@
-﻿using Amazon.Runtime;
-using Amazon.SQS.Model;
+﻿using Amazon.SQS.Model;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 
 namespace Frends.AmazonSQS.Receive.Definitions;
@@ -38,7 +38,7 @@ public class Result
     {
         ContentLength = response.ContentLength;
         StatusCode = response.HttpStatusCode;
-        Messages = response.Messages;
-        ResponseMetadata = response.ResponseMetadata;
+        Messages = response.Messages.Select(e => new Message(e)).ToList();
+        ResponseMetadata = new ResponseMetadata(response.ResponseMetadata);
     }
 }

--- a/Frends.AmazonSQS.Receive/Frends.AmazonSQS.Receive/Frends.AmazonSQS.Receive.csproj
+++ b/Frends.AmazonSQS.Receive/Frends.AmazonSQS.Receive/Frends.AmazonSQS.Receive.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
 	<TargetFrameworks>net6.0</TargetFrameworks>
-	<Version>1.0.0</Version>
+	<Version>1.1.0</Version>
 	<Authors>Frends</Authors>
 	<Copyright>Frends</Copyright>
 	<Company>Frends</Company>

--- a/Frends.AmazonSQS.Receive/Frends.AmazonSQS.Receive/Receive.cs
+++ b/Frends.AmazonSQS.Receive/Frends.AmazonSQS.Receive/Receive.cs
@@ -83,19 +83,14 @@ public class AmazonSQS
         if (connection.UseDefaultCredentials)
             return null;
 
-        switch (connection.CredentialsType)
+        return connection.CredentialsType switch
         {
-            case AWSCredentialsType.BasicAWSCredentials:
-                return new BasicAWSCredentials(connection.AccessKey, connection.SecretKey);
-            case AWSCredentialsType.AnonymousAWSCredentials:
-                return new AnonymousAWSCredentials();
-            case AWSCredentialsType.EnvironmentAWSCredentials:
-                return new EnvironmentVariablesAWSCredentials();
-            case AWSCredentialsType.SessionAWSCredentials:
-                return new SessionAWSCredentials(connection.AccessKey, connection.SecretKey, connection.SessionToken);
-            default:
-                throw new InvalidEnumArgumentException("Unknown credentials type.");
-        }
+            AWSCredentialsType.BasicAWSCredentials => new BasicAWSCredentials(connection.AccessKey, connection.SecretKey),
+            AWSCredentialsType.AnonymousAWSCredentials => new AnonymousAWSCredentials(),
+            AWSCredentialsType.EnvironmentAWSCredentials => new EnvironmentVariablesAWSCredentials(),
+            AWSCredentialsType.SessionAWSCredentials => new SessionAWSCredentials(connection.AccessKey, connection.SecretKey, connection.SessionToken),
+            _ => throw new InvalidEnumArgumentException("Unknown credentials type."),
+        };
     }
 
     /// <summary>
@@ -104,46 +99,27 @@ public class AmazonSQS
     [ExcludeFromCodeCoverage]
     private static RegionEndpoint RegionSelection(Region region)
     {
-        switch (region)
+        return region switch
         {
-            case Region.EuNorth1:
-                return RegionEndpoint.EUNorth1;
-            case Region.EuWest1:
-                return RegionEndpoint.EUWest1;
-            case Region.EuWest2:
-                return RegionEndpoint.EUWest2;
-            case Region.EuWest3:
-                return RegionEndpoint.EUWest3;
-            case Region.EuCentral1:
-                return RegionEndpoint.EUCentral1;
-            case Region.ApSoutheast1:
-                return RegionEndpoint.APSoutheast1;
-            case Region.ApSoutheast2:
-                return RegionEndpoint.APSoutheast2;
-            case Region.ApNortheast1:
-                return RegionEndpoint.APNortheast1;
-            case Region.ApNortheast2:
-                return RegionEndpoint.APNortheast2;
-            case Region.ApSouth1:
-                return RegionEndpoint.APSouth1;
-            case Region.CaCentral1:
-                return RegionEndpoint.CACentral1;
-            case Region.CnNorth1:
-                return RegionEndpoint.CNNorth1;
-            case Region.CnNorthWest1:
-                return RegionEndpoint.CNNorthWest1;
-            case Region.SaEast1:
-                return RegionEndpoint.SAEast1;
-            case Region.UsEast1:
-                return RegionEndpoint.USEast1;
-            case Region.UsEast2:
-                return RegionEndpoint.USEast2;
-            case Region.UsWest1:
-                return RegionEndpoint.USWest1;
-            case Region.UsWest2:
-                return RegionEndpoint.USWest2;
-            default:
-                return RegionEndpoint.EUNorth1;
-        }
+            Region.EuNorth1 => RegionEndpoint.EUNorth1,
+            Region.EuWest1 => RegionEndpoint.EUWest1,
+            Region.EuWest2 => RegionEndpoint.EUWest2,
+            Region.EuWest3 => RegionEndpoint.EUWest3,
+            Region.EuCentral1 => RegionEndpoint.EUCentral1,
+            Region.ApSoutheast1 => RegionEndpoint.APSoutheast1,
+            Region.ApSoutheast2 => RegionEndpoint.APSoutheast2,
+            Region.ApNortheast1 => RegionEndpoint.APNortheast1,
+            Region.ApNortheast2 => RegionEndpoint.APNortheast2,
+            Region.ApSouth1 => RegionEndpoint.APSouth1,
+            Region.CaCentral1 => RegionEndpoint.CACentral1,
+            Region.CnNorth1 => RegionEndpoint.CNNorth1,
+            Region.CnNorthWest1 => RegionEndpoint.CNNorthWest1,
+            Region.SaEast1 => RegionEndpoint.SAEast1,
+            Region.UsEast1 => RegionEndpoint.USEast1,
+            Region.UsEast2 => RegionEndpoint.USEast2,
+            Region.UsWest1 => RegionEndpoint.USWest1,
+            Region.UsWest2 => RegionEndpoint.USWest2,
+            _ => RegionEndpoint.EUNorth1,
+        };
     }
 }


### PR DESCRIPTION
#7 

## [1.1.0] - 2024-11-08
### Fixed
- Fixed dotnotation with Result properties by implementing internal classes for the properties.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes for Frends.AmazonSQS.Receive v1.1.0

- **New Features**
	- Introduced `Message` class to encapsulate Amazon SQS message attributes.
	- Added `ResponseMetadata` class to handle response metadata from Amazon SQS requests.

- **Bug Fixes**
	- Resolved an issue with dot notation in Result properties.

- **Refactor**
	- Simplified code structure by converting switch statements to expression-bodied members for better readability.

- **Chores**
	- Updated changelog and incremented version number to 1.1.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->