### PR TITLE
Bump version from 2.0.0 to 2.1.0

### DIFF
--- a/Frends.AmazonSQS.Send/CHANGELOG.md
+++ b/Frends.AmazonSQS.Send/CHANGELOG.md
@@ -1,5 +1,10 @@
 ﻿# Changelog
 
+## [2.1.0] - 2026-07-17
+
+### Changed
+- Made task class static to comply with Frends best practices
+
 ## [2.0.0] - 2025-07-23
 
 ### Added

--- a/Frends.AmazonSQS.Send/Frends.AmazonSQS.Send/Frends.AmazonSQS.Send.csproj
+++ b/Frends.AmazonSQS.Send/Frends.AmazonSQS.Send/Frends.AmazonSQS.Send.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
     <Authors>Frends</Authors>
     <Copyright>Frends</Copyright>
     <Company>Frends</Company>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Amazon SQS Send package to version 2.1.0.
  * No user-facing functionality or configuration changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->